### PR TITLE
Ensure log message about expression creation makes it log

### DIFF
--- a/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/CLanguageServerRegistry.java
+++ b/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/CLanguageServerRegistry.java
@@ -68,7 +68,7 @@ public class CLanguageServerRegistry {
 									enableExpression = new EnableExpression(this::getEvaluationContext,
 											ExpressionConverter.getDefault().perform(enabledWhenChildren[0]));
 								} catch (CoreException e) {
-									LspPlugin.logWarning(e.getMessage(), e);
+									LspPlugin.logWarning("Failed to create enable expression for " + configurationElement.getNamespaceIdentifier(), e);
 								}
 							}
 						}

--- a/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
+++ b/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspPlugin.java
@@ -41,8 +41,8 @@ public class LspPlugin extends AbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-		cLanguageServerProvider = new CLanguageServerRegistry().createCLanguageServerProvider();
 		plugin = this;
+		cLanguageServerProvider = new CLanguageServerRegistry().createCLanguageServerProvider();
 	}
 
 	@Override


### PR DESCRIPTION
The order of assigning plugin=this and CLanguageServerRegistry matter as CLanguageServerRegistry can log errors and if plugin isn't assigned before CLanguageServerRegistry is created the logging methods hit an NPE

Also, added a descriptive message to the log entry.