### PR TITLE
Fix wrong bundle name in Eclipse 2022-06

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui.test/META-INF/MANIFEST.MF
@@ -7,6 +7,6 @@ Bundle-Vendor: Eclipse.org
 Fragment-Host: org.eclipse.cdt.lsp.editor.ui;bundle-version="0.0.0"
 Require-Bundle: org.junit,
  org.eclipse.cdt.lsp,
- junit-jupiter-api
+ org.junit.jupiter.api
 Automatic-Module-Name: org.eclipse.cdt.lsp.editor.ui.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/bundles/org.eclipse.cdt.lsp.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse.org
 Fragment-Host: org.eclipse.cdt.lsp
 Require-Bundle: org.junit,
- junit-jupiter-api
+ org.junit.jupiter.api
 Automatic-Module-Name: org.eclipse.cdt.lsp.test
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
It must be org.junit.jupiter.api