### PR TITLE
Feature: edit server path and options in preference page

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.cdt.ui,
- org.eclipse.ui.editors
+ org.eclipse.ui.editors,
+ org.eclipse.cdt.core
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.cdt.lsp.editor.ui
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/CdtCLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/CdtCLanguageServerProvider.java
@@ -13,14 +13,55 @@
 
 package org.eclipse.cdt.lsp.editor.ui;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import org.eclipse.cdt.lsp.editor.ui.preference.LspEditorPreferences;
 import org.eclipse.cdt.lsp.server.DefaultCLanguageServerProvider;
+import org.eclipse.cdt.utils.CommandLineUtil;
+import org.eclipse.jface.preference.IPreferenceStore;
 
 
 public class CdtCLanguageServerProvider extends DefaultCLanguageServerProvider {
+	private static final IPreferenceStore preferenceStore = LspEditorUiPlugin.getDefault().getLsPreferences();
 
-	public CdtCLanguageServerProvider() {
-		// TODO Auto-generated constructor stub
+	
+	@Override
+	protected List<String> createCommands() {
+		List<String> commands = super.createCommands();
+		setPreferenceStoreDefaults(commands); // use the server provider settings as default
+		List<String> commandsFromStore = getCommandsFromStore();
+		if (commandsFromStore.isEmpty()) {
+			return commands;
+		}
+		return commandsFromStore;
 	}
-
+	
+	private void setPreferenceStoreDefaults(List<String> commands) {
+		if (!commands.isEmpty()) {
+			//set values in preference store:
+			preferenceStore.setDefault(LspEditorPreferences.SERVER_PATH, commands.get(0));
+			String args = "";
+			for (int i=1; i<commands.size(); i++) {
+				args = args + " " + commands.get(i);
+			}
+			preferenceStore.setDefault(LspEditorPreferences.SERVER_OPTIONS, args);
+		}
+	}
+	
+	private List<String> getCommandsFromStore(){
+		List<String> commands = new ArrayList<>();
+		String serverPath = preferenceStore.getString(LspEditorPreferences.SERVER_PATH);
+		if (serverPath.isBlank()) {
+			return commands;
+		}
+		commands.add(serverPath);
+		String options = preferenceStore.getString(LspEditorPreferences.SERVER_OPTIONS);
+		if (options.isBlank()) {
+			return commands;
+		}
+		commands.addAll(Arrays.asList(CommandLineUtil.argumentsToArray(options)));
+		return commands;
+	}
 }

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiMessages.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiMessages.java
@@ -26,6 +26,8 @@ public class LspEditorUiMessages extends NLS {
 	public static String LspEditorPreferencePage_description;
 	public static String LspEditorPreferencePage_preferLspEditor;
 	public static String LspEditorPreferencePage_preferLspEditor_description;
+	public static String LspEditorPreferencePage_server_options;
+	public static String LspEditorPreferencePage_server_path;
 	
 	public static String LspEditorPropertiesPage_projectSpecificSettings;
 

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiMessages.properties
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiMessages.properties
@@ -14,4 +14,7 @@
 LspEditorPreferencePage_description=LSP based C/C++ Editor Preferences
 LspEditorPreferencePage_preferLspEditor=Prefer C/C++ Editor (LSP)
 LspEditorPreferencePage_preferLspEditor_description=Prefer to use language server based C/C++ Editor instead of classic C/C++ Editor
+LspEditorPreferencePage_server_path=Path to the server executable:
+LspEditorPreferencePage_server_options=Command-line options for the server:
+
 LspEditorPropertiesPage_projectSpecificSettings=Project specific editor settings

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
@@ -47,6 +47,7 @@ public class LspEditorUiPlugin extends AbstractUIPlugin {
 		ServiceTracker<IWorkspace, IWorkspace> workspaceTracker = new ServiceTracker<>(context, IWorkspace.class, null);
 		workspaceTracker.open();
 		workspace = workspaceTracker.getService();
+		//getLsPreferences();
 	}
 
 	@Override
@@ -64,7 +65,7 @@ public class LspEditorUiPlugin extends AbstractUIPlugin {
 		return plugin;
 	}
 	
-	public IPreferenceStore getLspEditorPreferences() {
+	public IPreferenceStore getLsPreferences() {
 		if (preferenceStore == null) {
 			preferenceStore = new ScopedPreferenceStore(InstanceScope.INSTANCE, LspEditorUiPlugin.PLUGIN_ID);
 		}

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencePage.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferencePage.java
@@ -14,18 +14,29 @@
 package org.eclipse.cdt.lsp.editor.ui.preference;
 
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
+import org.eclipse.cdt.ui.newui.MultiLineTextFieldEditor;
+import org.eclipse.cdt.utils.CommandLineUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiMessages;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 public class LspEditorPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+	private FileFieldEditor serverPath;
+	private MultiLineTextFieldEditor serverOptions;
 
 	public LspEditorPreferencePage() {
 		super(GRID);
-		setPreferenceStore(LspEditorUiPlugin.getDefault().getLspEditorPreferences());
+		setPreferenceStore(LspEditorUiPlugin.getDefault().getLsPreferences());
 		setDescription(LspEditorUiMessages.LspEditorPreferencePage_description);
 	}
 
@@ -37,7 +48,52 @@ public class LspEditorPreferencePage extends FieldEditorPreferencePage implement
 	@Override
 	public void createFieldEditors() {
 		PreferenceMetadata<Boolean> prefer = LspEditorPreferences.getPreferenceMetadata();
-		addField(new BooleanFieldEditor(prefer.identifer(), prefer.name(), getFieldEditorParent()));
+		var booleanFieldEditor = new BooleanFieldEditor(prefer.identifer(), prefer.name(), getFieldEditorParent());
+		addField(booleanFieldEditor);
+		
+		serverPath = new FileFieldEditor(LspEditorPreferences.SERVER_PATH,
+				LspEditorUiMessages.LspEditorPreferencePage_server_path, getFieldEditorParent());
+		addField(serverPath);
+
+		
+		serverOptions = new MultiLineTextFieldEditor(LspEditorPreferences.SERVER_OPTIONS,
+				LspEditorUiMessages.LspEditorPreferencePage_server_options, getFieldEditorParent());
+		addField(serverOptions);
+	}
+		
+	@Override
+	public boolean performOk() {
+		writeServerPathToProvider(serverPath.getStringValue());
+		writeServerOptionsToProvider(serverOptions.getStringValue());
+		return super.performOk();
+	}
+	
+	private void writeServerPathToProvider(String path) {
+		if (path == null || path.isBlank()) {
+			return;
+		}
+		List<String> commands = LspPlugin.getDefault().getCLanguageServerProvider().getCommands();
+		if (commands != null && !commands.isEmpty()) {
+			commands.set(0, path);
+		} else if (commands == null) {
+			commands = new ArrayList<>();
+			commands.add(path);
+		}
+		LspPlugin.getDefault().getCLanguageServerProvider().setCommands(commands);
+	}
+	
+	private void writeServerOptionsToProvider(String options) {
+		if (options == null) {
+			return;
+		}
+		List<String> commands = LspPlugin.getDefault().getCLanguageServerProvider().getCommands();
+		if (commands != null && !commands.isEmpty()) {
+			String serverPath = commands.get(0); // save server path
+			commands.clear(); // clear all old options
+			commands.add(serverPath);
+			commands.addAll(Arrays.asList(CommandLineUtil.argumentsToArray(options)));
+		}
+		LspPlugin.getDefault().getCLanguageServerProvider().setCommands(commands);
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferences.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/preference/LspEditorPreferences.java
@@ -17,9 +17,12 @@ import org.eclipse.cdt.lsp.editor.ui.LspEditorUiMessages;
 import org.eclipse.core.runtime.preferences.PreferenceMetadata;
 
 public final class LspEditorPreferences {
+	public static final String PREFER_LSP_EDITOR = "prefer_lsp_editor";
+	public static final String SERVER_PATH = "server_path";
+	public static final String SERVER_OPTIONS = "server_options";
 	
 	public static PreferenceMetadata<Boolean> getPreferenceMetadata() {
-		return new PreferenceMetadata<>(Boolean.class, "prefer_lsp_editor", false, //$NON-NLS-1$
+		return new PreferenceMetadata<>(Boolean.class, PREFER_LSP_EDITOR, false, //$NON-NLS-1$
 				LspEditorUiMessages.LspEditorPreferencePage_preferLspEditor,
 				LspEditorUiMessages.LspEditorPreferencePage_preferLspEditor_description);
 	}

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/server/MockCLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/server/MockCLanguageServerProvider.java
@@ -12,30 +12,8 @@
 
 package org.eclipse.cdt.lsp.test.server;
 
-import java.util.List;
+import org.eclipse.cdt.lsp.server.DefaultCLanguageServerProvider;
 
-import org.eclipse.cdt.lsp.server.EnableExpression;
-import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
-
-public class MockCLanguageServerProvider implements ICLanguageServerProvider {
+public class MockCLanguageServerProvider extends DefaultCLanguageServerProvider {
 	
-	protected EnableExpression enableExpression;
-
-	@Override
-	public List<String> getCommands() {
-		return null;
-	}
-
-	@Override
-	public void setEnableExpression(EnableExpression enableExpression) {
-		this.enableExpression = enableExpression;
-	}
-
-	@Override
-	public boolean isEnabledFor(Object receiver) {
-		if (enableExpression != null)
-			return enableExpression.evaluate(receiver);			
-		return false;
-	}
-
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/DefaultCLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/DefaultCLanguageServerProvider.java
@@ -25,7 +25,7 @@ public class DefaultCLanguageServerProvider implements ICLanguageServerProvider 
 	public static final String PRETTY = "--pretty";
 	public static final String QUERY_DRIVER = "--query-driver=";
 	
-	protected final List<String> commands;
+	protected List<String> commands;
 	
 	protected EnableExpression enableExpression;
 	
@@ -38,21 +38,24 @@ public class DefaultCLanguageServerProvider implements ICLanguageServerProvider 
 		return commands;
 	}
 	
-	private List<String> createCommands() {
+	@Override
+	public void setCommands(List<String> commands) {
+		this.commands = commands;		
+	}
+	
+	protected List<String> createCommands() {
 		List<String> commands = new ArrayList<>();
-		if (commands.isEmpty()) {
-			IPath clangdLocation = PathUtil.findProgramLocation("clangd", null); //in case pathStr is null environment variable ${PATH} is inspected
-			if (clangdLocation != null) {
-				commands.add(clangdLocation.toOSString());
-				commands.add(CLANG_TIDY);
-				commands.add(BACKGROUND_INDEX);
-				commands.add(COMPLETION_STYLE);
-				commands.add(PRETTY);
-				// clangd will execute drivers and fetch necessary include paths to compile your code:
-				IPath compilerLocation = PathUtil.findProgramLocation("gcc", null);
-				if (compilerLocation != null) {
-					commands.add(QUERY_DRIVER + compilerLocation.removeLastSegments(1).append(IPath.SEPARATOR + "*"));
-				}
+		IPath clangdLocation = PathUtil.findProgramLocation("clangd", null); //in case pathStr is null environment variable ${PATH} is inspected
+		if (clangdLocation != null) {
+			commands.add(clangdLocation.toOSString());
+			commands.add(CLANG_TIDY);
+			commands.add(BACKGROUND_INDEX);
+			commands.add(COMPLETION_STYLE);
+			commands.add(PRETTY);
+			// clangd will execute drivers and fetch necessary include paths to compile your code:
+			IPath compilerLocation = PathUtil.findProgramLocation("gcc", null);
+			if (compilerLocation != null) {
+				commands.add(QUERY_DRIVER + compilerLocation.removeLastSegments(1).append(IPath.SEPARATOR + "*"));
 			}
 		}
 		return commands;
@@ -76,5 +79,4 @@ public class DefaultCLanguageServerProvider implements ICLanguageServerProvider 
 		//language server is always enabled when no enable expression has been defined in the extension point: 
 		return true;
 	}
-
 }

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/server/ICLanguageServerProvider.java
@@ -23,6 +23,13 @@ public interface ICLanguageServerProvider {
 	 */
 	public List<String> getCommands();
 	
+	
+	/**
+	 * The command list includes the location of the language server followed by its calling arguments.
+	 * 
+	 */
+	public void setCommands(List<String> commands);
+	
 	/**
 	 * The enable expression is used to determine if the language server should be enabled. 
 	 * 


### PR DESCRIPTION
The server path and options can be edited for the used server provider. The default values are the commands delivered from the server provider.

In Windows it looks like this:
![image](https://user-images.githubusercontent.com/123444711/220905308-2ce29c19-6680-4b84-987f-366ce23be12c.png)


TODO: add tests and create a new issue for the topic that the LS has to be restarted when the server binary or options changes