### PR TITLE
[#23] Refresh open editors when compile_commands.json changes

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.cdt.ui,
  org.eclipse.ui.editors,
- org.eclipse.cdt.core
+ org.eclipse.cdt.core,
+ org.eclipse.jface.text
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.cdt.lsp.editor.ui
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/LspEditorUiPlugin.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.cdt.lsp.editor.ui;
 
+import org.eclipse.cdt.lsp.editor.ui.clangd.CompileCommandsMonitor;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -27,6 +28,7 @@ import org.osgi.util.tracker.ServiceTracker;
 public class LspEditorUiPlugin extends AbstractUIPlugin {
 	private IPreferenceStore preferenceStore;
 	private IWorkspace workspace;
+	private CompileCommandsMonitor compileCommandsMonitor;
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.cdt.lsp.editor.ui"; //$NON-NLS-1$
@@ -47,12 +49,14 @@ public class LspEditorUiPlugin extends AbstractUIPlugin {
 		ServiceTracker<IWorkspace, IWorkspace> workspaceTracker = new ServiceTracker<>(context, IWorkspace.class, null);
 		workspaceTracker.open();
 		workspace = workspaceTracker.getService();
+		compileCommandsMonitor = new CompileCommandsMonitor(workspace).start();
 		//getLsPreferences();
 	}
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
+		compileCommandsMonitor.stop();
 		super.stop(context);
 	}
 

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CompileCommandsMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CompileCommandsMonitor.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2023 COSEDA Technologies GmbH and others.
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Dominic Scharfe (COSEDA Technologies GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.cdt.lsp.editor.ui.clangd;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IReusableEditor;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.progress.UIJob;
+import org.eclipse.ui.statushandlers.StatusManager;
+
+/**
+ * Detects changes (add/delete/content) of JSON Compilation Database Format
+ * Specification files ({@value #CDBF_SPECIFICATION_JSON_FILE}) in the
+ * {@link IWorkspace workspace} and
+ * {@link CompileCommandsMonitor#refreshEditor(IEditorPart) refreshes} open
+ * editors if their {@link IEditorPart#getEditorInput()} is affected.
+ */
+public class CompileCommandsMonitor {
+	private static final String CDBF_SPECIFICATION_JSON_FILE = "compile_commands.json";
+
+	private final IResourceChangeListener listener = new IResourceChangeListener() {
+		@Override
+		public void resourceChanged(IResourceChangeEvent event) {
+			Set<IProject> projects = collectAffectedProjects(event);
+
+			if (!projects.isEmpty()) {
+				// collect all open editors which have cpp files as input and refresh them
+				Arrays.stream(PlatformUI.getWorkbench().getWorkbenchWindows()).map(IWorkbenchWindow::getPages)
+						.flatMap(Arrays::stream).map(IWorkbenchPage::getEditorReferences).flatMap(Arrays::stream)
+						.flatMap(ref -> Stream.ofNullable(ref.getEditor(false))).forEach(editor -> {
+							IFile file = Adapters.adapt(editor.getEditorInput(), IFile.class);
+
+							if (isCppFile(file) && projects.contains(file.getProject())) {
+								refreshEditor(editor, file);
+							}
+						});
+			}
+		}
+
+		private boolean isCppFile(IResource resource) {
+			if (resource instanceof IFile) {
+				var contentTypes = Platform.getContentTypeManager().findContentTypesFor(((IFile) resource).getName());
+				return Arrays.stream(contentTypes).anyMatch(contentType -> {
+					var id = contentType.getId();
+					return id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header"));
+				});
+			}
+			return false;
+		}
+
+		/**
+		 * Collects all projects where where compile_commands.json files were
+		 * added/removed/changed
+		 */
+		private Set<IProject> collectAffectedProjects(IResourceChangeEvent event) {
+			Set<IProject> projects = new HashSet<>();
+
+			if (event.getDelta() != null && event.getType() == IResourceChangeEvent.POST_CHANGE) {
+				try {
+					event.getDelta().accept(delta -> {
+						if ((delta.getKind() == IResourceDelta.ADDED || delta.getKind() == IResourceDelta.REMOVED
+								|| (delta.getFlags() & IResourceDelta.CONTENT) != 0)
+								&& CDBF_SPECIFICATION_JSON_FILE.equals(delta.getResource().getName())) {
+							projects.add(delta.getResource().getProject());
+						}
+
+						return true;
+					});
+				} catch (CoreException e) {
+					StatusManager.getManager().handle(e, LspEditorUiPlugin.PLUGIN_ID);
+				}
+			}
+			return projects;
+		}
+	};
+
+	private final IWorkspace workspace;
+
+	public CompileCommandsMonitor(IWorkspace workspace) {
+		this.workspace = workspace;
+	}
+
+	public CompileCommandsMonitor start() {
+		workspace.addResourceChangeListener(listener);
+		return this;
+	}
+
+	public void stop() {
+		workspace.removeResourceChangeListener(listener);
+	}
+
+	private static void refreshEditor(IEditorPart editor, IFile file) {
+		ITextViewer textViewer = Adapters.adapt(editor, ITextViewer.class);
+
+		// Notify clangd about the file change --> doesn't seem to work
+//		org.eclipse.lsp4e.LanguageServers.forDocument(textViewer.getDocument()).computeFirst(server -> {
+//			server.getWorkspaceService()
+//					.didChangeWatchedFiles(new DidChangeWatchedFilesParams(Arrays.asList(new FileEvent(
+//							file.getProject().getFile(CDBF_SPECIFICATION_JSON_FILE).getLocationURI().toASCIIString(),
+//							FileChangeType.Changed))));
+//			return new CompletableFuture<>();
+//		});
+
+		// Refresh the editors after 5 seconds -> see https://reviews.llvm.org/D92663
+		UIJob.create("Refresh Editors", monitor -> {
+			int rangeOffset = textViewer.getTopIndexStartOffset();
+			int rangeLength = textViewer.getBottomIndexEndOffset() - rangeOffset;
+			editor.getSite().getPage().reuseEditor((IReusableEditor) editor, editor.getEditorInput());
+			textViewer.revealRange(rangeOffset, rangeLength);
+		}).schedule(5000);
+	}
+}


### PR DESCRIPTION
Update open editors when compile_commands.json file of the project of the edited file is added/removed/changed.

This makes use of clangd hot-reload, see https://reviews.llvm.org/D92663.
I thought it should be possible to notify clangd via didChangeWatchedFiles, however clangd receives the command but doesn't seem to update the compilation data base.