### PR TITLE
[#26] add missing contentTypeBindings

### DIFF
--- a/bundles/org.eclipse.cdt.lsp.editor.ui.test/src/org/eclipse/cdt/lsp/editor/ui/test/preference/LspEditorPreferencesTesterTest.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui.test/src/org/eclipse/cdt/lsp/editor/ui/test/preference/LspEditorPreferencesTesterTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+
 import org.eclipse.cdt.lsp.LspPlugin;
 import org.eclipse.cdt.lsp.editor.ui.test.TestUtils;
 import org.eclipse.cdt.lsp.server.ICLanguageServerProvider;
@@ -15,18 +17,24 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.io.TempDir;
 
 
 public class LspEditorPreferencesTesterTest {
 	private static final String FILE_CONTENT = "// sample file content";
 	private static final String MAIN_CPP = "main.cpp";
-	private static final String EXTERNAL_HEADER_HPP = "ExternalHeader.hpp";
+	private static final String HEADER_HPP = "header.hpp";
+	private static final String MAIN_C = "main.c";
+	private static final String HEADER_H = "header.h";
+	//private static final String EXTERNAL_HEADER_HPP = "ExternalHeader.hpp";
 	private IProject project;
 	
-	@TempDir
-	private File tempDir;
+	// @TempDir -> does not work with org.junit.jupiter.api. Needs junit-jupiter-api and junit-jupiter-params.
+	// These packages are not accessible on the CI build server because we build with Eclipse 2022-06
+	// Path tempDir = Files.createTempFile("ExternalHeader", ".hpp", null);
 	
+	private File createTempHppHeaderfile() throws IOException {
+		return Files.createTempFile("ExternalHeader", ".hpp").toFile();
+	}
 	
 	@BeforeEach
 	public void setUp(TestInfo testInfo) throws CoreException {
@@ -81,11 +89,11 @@ public class LspEditorPreferencesTesterTest {
 	}
 	
 	/**
-	 * Tests whether the C/C++ Editor is used for a resource to open whose project has "Prefer C/C++ Editor (LSP)" disabled.
+	 * Tests whether the C/C++ Editor is used for a C++ source file to open whose project has "Prefer C/C++ Editor (LSP)" disabled.
 	 * @throws UnsupportedEncodingException 
 	 */
 	@Test
-	public void testEditorUsedToOpenFile_WITHOUT_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+	public void testEditorUsedToOpenCppFile_WITHOUT_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
 		//GIVEN is a project with DISABLED "Prefer C/C++ Editor (LSP)" in the preferences:
 		TestUtils.setLspPreferred(project, false);
 		//AND a file exits in the given project:
@@ -94,14 +102,15 @@ public class LspEditorPreferencesTesterTest {
 		var editorPart = TestUtils.openInEditor(file);
 		//THEN it will be opened in the C/C++ Editor:
 		assertEquals(LspPlugin.C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
 	}
 	
 	/**
-	 * Tests whether the C/C++ Editor (LSP) is used for a resource to open whose project has "Prefer C/C++ Editor (LSP)" enabled.
+	 * Tests whether the C/C++ Editor (LSP) is used for a C++ source file to open whose project has "Prefer C/C++ Editor (LSP)" enabled.
 	 * @throws UnsupportedEncodingException 
 	 */
 	@Test
-	public void testEditorUsedToOpenFile_WITH_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+	public void testEditorUsedToOpenCppFile_WITH_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
 		//GIVEN is a project with ENABLED "Prefer C/C++ Editor (LSP)" in the preferences:
 		TestUtils.setLspPreferred(project, true);
 		//AND a file exits in the given project:
@@ -110,6 +119,109 @@ public class LspEditorPreferencesTesterTest {
 		var editorPart = TestUtils.openInEditor(file);
 		//THEN it will be opened in the C/C++ Editor (LSP):
 		assertEquals(LspPlugin.LSP_C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor is used for a C++ header file to open whose project has "Prefer C/C++ Editor (LSP)" disabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCppHeaderFile_WITHOUT_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with DISABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, false);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, HEADER_HPP, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor:
+		assertEquals(LspPlugin.C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor (LSP) is used for a C++ header file to open whose project has "Prefer C/C++ Editor (LSP)" enabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCppHeaderFile_WITH_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with ENABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, true);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, HEADER_HPP, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor (LSP):
+		assertEquals(LspPlugin.LSP_C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor is used for a C source file to open whose project has "Prefer C/C++ Editor (LSP)" disabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCFile_WITHOUT_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with DISABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, false);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, MAIN_C, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor:
+		assertEquals(LspPlugin.C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor (LSP) is used for a C source file to open whose project has "Prefer C/C++ Editor (LSP)" enabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCFile_WITH_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with ENABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, true);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, MAIN_C, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor (LSP):
+		assertEquals(LspPlugin.LSP_C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor is used for a C header file to open whose project has "Prefer C/C++ Editor (LSP)" disabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCHeaderFile_WITHOUT_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with DISABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, false);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, HEADER_HPP, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor:
+		assertEquals(LspPlugin.C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
+	}
+	
+	/**
+	 * Tests whether the C/C++ Editor (LSP) is used for a C header file to open whose project has "Prefer C/C++ Editor (LSP)" enabled.
+	 * @throws UnsupportedEncodingException 
+	 */
+	@Test
+	public void testEditorUsedToOpenCHeaderFile_WITH_LsEditorPreferred() throws CoreException, UnsupportedEncodingException {
+		//GIVEN is a project with ENABLED "Prefer C/C++ Editor (LSP)" in the preferences:
+		TestUtils.setLspPreferred(project, true);
+		//AND a file exits in the given project:
+		var file = TestUtils.createFile(project, HEADER_H, FILE_CONTENT);
+		//WHEN this file will be opened:
+		var editorPart = TestUtils.openInEditor(file);
+		//THEN it will be opened in the C/C++ Editor (LSP):
+		assertEquals(LspPlugin.LSP_C_EDITOR_ID, editorPart.getEditorSite().getId());
+		TestUtils.closeEditor(editorPart, false);
 	}
 	
 	/**
@@ -119,12 +231,14 @@ public class LspEditorPreferencesTesterTest {
 	@Test
 	public void testLsEnableByExternalUriTest_NoEditorOpen() throws CoreException, IOException {
 		//GIVEN is an external file which does not exists in the given project and is not opened:
-		File externalFile = new File(tempDir, EXTERNAL_HEADER_HPP);
+		File externalFile = createTempHppHeaderfile();
 		//AND a ICLanguageServerProvider which uses LspEditorPreferencesTester as enabledWhen tester:
 		ICLanguageServerProvider cLanguageServerProvider = LspPlugin.getDefault().getCLanguageServerProvider();
 		//WHEN the LspEditorPreferencesTester gets called by the property tester in the enabledWhen element of the serverProvider extension point,
 		//THEN the LspEditorPreferencesTester.test returns FALSE for the given file URI:
 		assertTrue(!cLanguageServerProvider.isEnabledFor(externalFile.toURI()));		
+		//ensure clean up
+		externalFile.delete();
 	}
 	
 	/**
@@ -133,7 +247,7 @@ public class LspEditorPreferencesTesterTest {
 	@Test
 	public void testLsEnableByExternalUriTest_OpenedInLspCEditor() throws CoreException, IOException {
 		//GIVEN is an existing external file:
-		File externalFile = new File(tempDir, EXTERNAL_HEADER_HPP);
+		File externalFile = createTempHppHeaderfile();
 		externalFile.createNewFile();
 		//AND it's opened in the LSP based C/C++ Editor:
 		var editor = TestUtils.openInEditor(externalFile.toURI(), LspPlugin.LSP_C_EDITOR_ID);
@@ -143,6 +257,8 @@ public class LspEditorPreferencesTesterTest {
 		//THEN the LspEditorPreferencesTester.test returns TRUE for the given file URI:
 		assertTrue(cLanguageServerProvider.isEnabledFor(externalFile.toURI()));	
 		TestUtils.closeEditor(editor, false);
+		//ensure clean up
+		externalFile.delete();
 	}
 	
 	/**
@@ -151,7 +267,7 @@ public class LspEditorPreferencesTesterTest {
 	@Test
 	public void testLsEnableByExternalUriTest_OpenedInCEditor() throws CoreException, IOException {
 		//GIVEN is an existing external file:
-		File externalFile = new File(tempDir, EXTERNAL_HEADER_HPP);
+		File externalFile = createTempHppHeaderfile();
 		externalFile.createNewFile();
 		//AND it's opened in the C/C++ Editor:
 		var editor = TestUtils.openInEditor(externalFile.toURI(), LspPlugin.C_EDITOR_ID);
@@ -161,6 +277,8 @@ public class LspEditorPreferencesTesterTest {
 		//THEN the LspEditorPreferencesTester.test returns FALSE for the given file URI:
 		assertTrue(!cLanguageServerProvider.isEnabledFor(externalFile.toURI()));	
 		TestUtils.closeEditor(editor, false);
+		//ensure clean up
+		externalFile.delete();
 	}
 
 }

--- a/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CompileCommandsMonitor.java
+++ b/bundles/org.eclipse.cdt.lsp.editor.ui/src/org/eclipse/cdt/lsp/editor/ui/clangd/CompileCommandsMonitor.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.eclipse.cdt.lsp.LspUtils;
 import org.eclipse.cdt.lsp.editor.ui.LspEditorUiPlugin;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -71,8 +72,7 @@ public class CompileCommandsMonitor {
 			if (resource instanceof IFile) {
 				var contentTypes = Platform.getContentTypeManager().findContentTypesFor(((IFile) resource).getName());
 				return Arrays.stream(contentTypes).anyMatch(contentType -> {
-					var id = contentType.getId();
-					return id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header"));
+					return LspUtils.isCContentType(contentType.getId());
 				});
 			}
 			return false;

--- a/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
+++ b/bundles/org.eclipse.cdt.lsp.test/src/org/eclipse/cdt/lsp/test/LspUtilsTest.java
@@ -1,0 +1,41 @@
+package org.eclipse.cdt.lsp.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.cdt.core.CCorePlugin;
+import org.eclipse.cdt.lsp.LspUtils;
+import org.junit.jupiter.api.Test;
+
+class LspUtilsTest {
+
+	@Test
+	void testIsCContentType_EmptyId() {
+		assertTrue(!LspUtils.isCContentType(""));
+	}
+	
+	@Test
+	void testIsCContentType_CppContentTypeFromTM4E() {
+		assertTrue(LspUtils.isCContentType("lng.cpp"));
+	}
+	
+	@Test
+	void testIsCContentType_CONTENT_TYPE_CSOURCE() {
+		assertTrue(LspUtils.isCContentType(CCorePlugin.CONTENT_TYPE_CSOURCE));
+	}
+	
+	@Test
+	void testIsCContentType_CONTENT_TYPE_CHEADER() {
+		assertTrue(LspUtils.isCContentType(CCorePlugin.CONTENT_TYPE_CHEADER));
+	}
+	
+	@Test
+	void testIsCContentType_CONTENT_TYPE_CXXSOURCE() {
+		assertTrue(LspUtils.isCContentType(CCorePlugin.CONTENT_TYPE_CXXSOURCE));
+	}
+	
+	@Test
+	void testIsCContentType_CONTENT_TYPE_CXXHEADER() {
+		assertTrue(LspUtils.isCContentType(CCorePlugin.CONTENT_TYPE_CXXHEADER));
+	}
+
+}

--- a/bundles/org.eclipse.cdt.lsp/plugin.xml
+++ b/bundles/org.eclipse.cdt.lsp/plugin.xml
@@ -17,7 +17,16 @@
          <contentTypeBinding
                contentTypeId="org.eclipse.cdt.core.cxxSource">
          </contentTypeBinding>
+         <contentTypeBinding
+               contentTypeId="lng.cpp"> <!-- // TODO: The content type definition from TM4E "lng.cpp" can be omitted here if either https://github.com/eclipse-cdt/cdt/pull/310 or 
+		// https://github.com/eclipse/tm4e/pull/500 has been merged. --> 
+         </contentTypeBinding>       
       </editor>
+      <editorContentTypeBinding
+            contentTypeId="lng.cpp"
+            editorId="org.eclipse.cdt.ui.editor.CEditor"> <!-- // TODO: The content type definition from TM4E "lng.cpp" can be omitted here if either https://github.com/eclipse-cdt/cdt/pull/310 or 
+		// https://github.com/eclipse/tm4e/pull/500 has been merged. --> 
+      </editorContentTypeBinding>
    </extension>
    <extension
          point="org.eclipse.lsp4e.languageServer">

--- a/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
+++ b/bundles/org.eclipse.cdt.lsp/src/org/eclipse/cdt/lsp/LspUtils.java
@@ -1,0 +1,17 @@
+package org.eclipse.cdt.lsp;
+
+public class LspUtils {
+	
+	/**
+	 * Checks if given ContentType id matches the content types for C/C++ files.
+	 * 
+	 * @param id ContentType id
+	 * @return {@code true} if C/C++ content type
+	 */
+	public static boolean isCContentType(String id) {
+		// TODO: The content type definition from TM4E "lng.cpp" can be omitted if either https://github.com/eclipse-cdt/cdt/pull/310 or 
+		// https://github.com/eclipse/tm4e/pull/500 has been merged.
+		return ( id.startsWith("org.eclipse.cdt.core.c") && (id.endsWith("Source") || id.endsWith("Header")) ) || "lng.cpp".equals(id);
+	}
+
+}


### PR DESCRIPTION
The org.eclipse.tm4e.language_pack plug-in adds content types for C/C++ files. These content types needs to be considered during filtering